### PR TITLE
fix issue 76

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
                                       { name: "Ben Peters",
                                         mailto: "BenjamP@microsoft.com",
                                         company: "Microsoft",
-                                        companyURL: "http://www.microsoft.com",
+                                        companyURL: "https://www.microsoft.com",
                                         note: "until 23 February 2015",
                                         w3cid: "69167" }]
                    ,   wg:           "Web Platform Working Group"
@@ -119,7 +119,7 @@
       <section>
          <h2>Introduction</h2>
          <p>This document describes editing related additions to 2 events -
-            <a href="https://w3c.github.io/uievents/#beforeinput">Input</a>
+            <a href="https://w3c.github.io/uievents/#event-type-input">input</a>
             and <a href="https://w3c.github.io/uievents/#beforeinput">beforeinput</a>
             which are described in the UI events spec [[!UI-EVENTS]]. The goal
             of these events is to allow authors to understand and/or override


### PR DESCRIPTION
This commit resolves [issue #76](https://github.com/w3c/input-events/issues/76), updating the link and link text.

Additionally updating the link to Microsoft.com, in the respecConfig from http to https