### PR TITLE
add read only mode of drag-data-store, fixes #95

### DIFF
--- a/index.html
+++ b/index.html
@@ -1508,11 +1508,6 @@
             to the document in a {{DataTransfer}} object if there is relevant
             data.
           </p>
-          <p>
-            <dfn data-dfn-for="InputEvent">getTargetRanges()</dfn> returns an
-            arrays <a>StaticRanges</a> that will be affected by the event if it
-            is not cancelled.
-          </p>
           <table class="parameters simple">
             <thead>
               <tr>
@@ -1543,6 +1538,10 @@
                 <td>
                   A prepopulated {{DataTransfer}} object so that:
                   <ol>
+                    <li>The {{DataTransfer}} object's <a data-cite=
+                    "html/dnd.html#drag-data-store">drag data store</a> is in
+                    <a data-cite="html/dnd.html#drag-data-store">read-only</a>
+                    mode. [[HTML]]
                     <li>The {{DataTransfer}} object's <a data-cite=
                     "html/dnd.html#drag-data-store-item-list">drag data store
                     item list</a> contains one entry with the <a data-cite=
@@ -1582,6 +1581,11 @@
               </tr>
             </tbody>
           </table>
+          <p>
+            <dfn data-dfn-for="InputEvent">getTargetRanges()</dfn> returns an
+            arrays <a>StaticRanges</a> that will be affected by the event if it
+            is not cancelled.
+          </p>
         </section><!-- interface-InputEvent-Attributes -->
         <section id="interface-InputEvent-Methods" data-dfn-for="InputEvent">
           <h5>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/input-events/pull/99.html" title="Last updated on Jun 30, 2019, 6:38 AM UTC (2687f75)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/input-events/99/184ea1a...2687f75.html" title="Last updated on Jun 30, 2019, 6:38 AM UTC (2687f75)">Diff</a>