### PR TITLE
add read only mode of drag-data-store, fixes #95

### DIFF
--- a/index.html
+++ b/index.html
@@ -1451,11 +1451,6 @@
             to the document in a {{DataTransfer}} object if there is relevant
             data.
           </p>
-          <p>
-            <dfn data-dfn-for="InputEvent">getTargetRanges()</dfn> returns an
-            arrays <a>StaticRanges</a> that will be affected by the event if it
-            is not cancelled.
-          </p>
           <table class="parameters simple">
             <thead>
               <tr>
@@ -1488,7 +1483,7 @@
                   <ol>
                     <li>The {{DataTransfer}} object's <a data-cite=
                     "html/dnd.html#drag-data-store">drag data store</a> is in
-                    <a data-cite="html/dnd.html#drag-data-store">read-only</a>
+                    <a data-cite="html/dnd.html#concept-dnd-ro">read-only</a>
                     mode. [[HTML]]
                     </li>
                     <li>The {{DataTransfer}} object's <a data-cite=
@@ -1530,6 +1525,11 @@
               </tr>
             </tbody>
           </table>
+          <p>
+            <dfn data-dfn-for="InputEvent">getTargetRanges()</dfn> returns an
+            arrays <a>StaticRanges</a> that will be affected by the event if it
+            is not cancelled.
+          </p>
         </section><!-- interface-InputEvent-Attributes -->
         <section id="interface-InputEvent-Methods" data-dfn-for="InputEvent">
           <h5>

--- a/index.html
+++ b/index.html
@@ -1263,10 +1263,6 @@
                   plaintext data that is to be taken from or added to the document
                   in a <a>DataTransfer</a> object if there is relevant data.
                </p>
-               <p><dfn data-dfn-for=InputEvent>getTargetRanges()</dfn>
-                  returns an arrays <a>StaticRanges</a> that will be affected
-                  by the event if it is not cancelled.
-               </p>
                <table class="parameters simple">
                   <thead>
                      <tr>
@@ -1288,6 +1284,10 @@
                         <td>
                            A prepopulated <a>DataTransfer</a> object so that:
                            <ol>
+                              <li>The <a>DataTransfer</a> object's <a data-cite="html/dnd.html#drag-data-store">drag data store</a> is in
+                                 <a data-cite="html/dnd.html#drag-data-store">read-only</a>
+                                 mode. [[HTML]]
+                              </li>
                               <li>The <a>DataTransfer</a> object's <a href="https://html.spec.whatwg.org/multipage/interaction.html#drag-data-store-item-list">drag data store item list</a>
                                  contains one entry with the <a href="https://html.spec.whatwg.org/multipage/interaction.html#the-drag-data-item-type-string">drag data item type string</a>
                                  <code>"text/html"</code>, whose <a href="https://html.spec.whatwg.org/multipage/interaction.html#the-drag-data-item-kind">kind</a>
@@ -1316,6 +1316,10 @@
                      </tr>
                   </tbody>
                </table>
+               <p><dfn data-dfn-for=InputEvent>getTargetRanges()</dfn>
+                  returns an arrays <a>StaticRanges</a> that will be affected
+                  by the event if it is not cancelled.
+               </p>
             </section>
             <!-- interface-InputEvent-Attributes -->
             <section id="interface-InputEvent-Methods" dfn-for="InputEvent">


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/input-events/pull/100.html" title="Last updated on Jul 13, 2019, 8:44 PM UTC (7604831)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/input-events/100/e16008f...7604831.html" title="Last updated on Jul 13, 2019, 8:44 PM UTC (7604831)">Diff</a>