### PR TITLE
Add conformance section

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,6 +124,7 @@
         both before and after editing occurs.
       </p>
     </section>
+    <section id="conformance"></section>
     <section>
       <h2>
         Definitions


### PR DESCRIPTION
All references were listed as Informative references because Respec assumes that a spec is informative-only in the absence of a conformance section, see discussion in:
https://github.com/w3c/respec/issues/2580


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/input-events/pull/104.html" title="Last updated on Nov 21, 2019, 10:29 AM UTC (54d2346)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/input-events/104/657725f...tidoust:54d2346.html" title="Last updated on Nov 21, 2019, 10:29 AM UTC (54d2346)">Diff</a>