### PR TITLE
Editorial: Link editing host to its HTML spec definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,7 +239,7 @@
       </p>
       <p>
         Input events are <a data-cite="uievents#dispatch">dispatched</a>
-        [[UI-EVENTS]] on elements that act as editing hosts, including elements
+        [[UI-EVENTS]] on elements that act as [=editing hosts=], including elements
         with the contenteditable attribute set, <a data-link-type="element"
         data-cite="html/form-elements.html#the-textarea-element">`textarea`</a>
         elements, and <code><a data-link-type="element" data-cite=
@@ -1649,7 +1649,7 @@
           </table>
           <p>
             returns , unless the inputType is <code>"historyUndo"</code> or
-            <code>"historyRedo"</code> or the editing host is not a
+            <code>"historyRedo"</code> or the [=editing host=] is not a
             contenteditable element, in which case it returns an empty Array.
           </p>
         </section><!-- interface-InputEvent-Methods -->

--- a/index.html
+++ b/index.html
@@ -239,10 +239,11 @@
       </p>
       <p>
         Input events are <a data-cite="uievents#dispatch">dispatched</a>
-        [[UI-EVENTS]] on elements that act as [=editing hosts=], including elements
-        with the contenteditable attribute set, <a data-link-type="element"
-        data-cite="html/form-elements.html#the-textarea-element">`textarea`</a>
-        elements, and <code><a data-link-type="element" data-cite=
+        [[UI-EVENTS]] on elements that act as [=editing hosts=], including
+        elements with the contenteditable attribute set, <a data-link-type=
+        "element" data-cite=
+        "html/form-elements.html#the-textarea-element">`textarea`</a> elements,
+        and <code><a data-link-type="element" data-cite=
         "html/input.html#the-input-element">input</a></code> elements that
         permit text input.
       </p>
@@ -1543,6 +1544,7 @@
                     "html/dnd.html#drag-data-store">drag data store</a> is in
                     <a data-cite="html/dnd.html#concept-dnd-ro">read-only</a>
                     mode. [[HTML]]
+                    </li>
                     <li>The {{DataTransfer}} object's <a data-cite=
                     "html/dnd.html#drag-data-store-item-list">drag data store
                     item list</a> contains one entry with the <a data-cite=


### PR DESCRIPTION
Hi! I recently [imported](https://github.com/whatwg/html/pull/5253/) the definition of `editing host` from the execCommand spec to the HTML spec.

@marcoscaceres mentioned that the next steps are to find other specs that currently use `editing host` and to do the following:
1. remove any redefinitions
2. link the singular and plural forms of `editing host` to the [current definition in the HTML spec](https://html.spec.whatwg.org/multipage/interaction.html#editing-host).

In this PR, I have
1. linked `editing host` to the current definition in the HTML spec.

Thank you!

Similar PRs related to the `editing host` import:
* [PR 109 - Clipboard APIs](https://github.com/w3c/clipboard-apis/pull/109)
* [PR 119 - Selection API](https://github.com/w3c/selection-api/pull/119)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/janiceshiu/input-events/pull/108.html" title="Last updated on Feb 24, 2020, 5:58 AM UTC (de471e2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/input-events/108/706548d...janiceshiu:de471e2.html" title="Last updated on Feb 24, 2020, 5:58 AM UTC (de471e2)">Diff</a>