### PR TITLE
Add insertion from image library part of "insertFromPaste", fixes #117

### DIFF
--- a/index.html
+++ b/index.html
@@ -617,7 +617,7 @@
                   <code>"insertFromDrop"</code>
                 </td>
                 <td>
-                  insert content into the DOM by means of drop
+                  insert content by means of drop
                 </td>
                 <td>
                   No
@@ -634,7 +634,7 @@
                   <code>"insertFromPaste"</code>
                 </td>
                 <td>
-                  paste
+                  paste content from clipboard or paste image from client provided image library
                 </td>
                 <td>
                   No
@@ -651,7 +651,7 @@
                   <code>"insertFromPasteAsQuotation"</code>
                 </td>
                 <td>
-                  paste content as a quotation
+                  paste content from the clipboard as a quotation
                 </td>
                 <td>
                   No
@@ -703,7 +703,7 @@
                   <code>"insertFromComposition"</code>
                 </td>
                 <td>
-                  insert into the DOM a finalized composed string that will not
+                  insert a finalized composed string that will not
                   form part of the next composition string
                 </td>
                 <td>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/input-events/pull/119.html" title="Last updated on Jul 1, 2021, 11:34 PM UTC (252c63d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/input-events/119/bd15b08...252c63d.html" title="Last updated on Jul 1, 2021, 11:34 PM UTC (252c63d)">Diff</a>