### PR TITLE
Eliminate insertFromComposition, deleteByComposition, and deleteCompositionText

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,10 @@
             ],
           },
         ],
-        xref: ["HTML"],
+        xref: [
+          "HTML",
+          "uievents"
+        ]
       };
     </script>
   </head>
@@ -311,7 +314,6 @@
                 <td>
                   <code>"insertText"</code>,
                   <code>"insertCompositionText"</code>,
-                  <code>"insertFromComposition"</code>,
                   <code>"formatSetBlockTextDirection"</code>,
                   <code>"formatSetInlineTextDirection"</code>,
                   <code>"formatBackColor"</code>,
@@ -357,7 +359,6 @@
                 <td>
                   <code>"insertText"</code>,
                   <code>"insertCompositionText"</code>,
-                  <code>"insertFromComposition"</code>,
                   <code>"insertFromPaste"</code>,
                   <code>"insertFromPasteAsQuotation"</code>,
                   <code>"insertFromDrop"</code>,
@@ -700,24 +701,6 @@
               </tr>
               <tr>
                 <td>
-                  <code>"insertFromComposition"</code>
-                </td>
-                <td>
-                  insert a finalized composed string that will not
-                  form part of the next composition string
-                </td>
-                <td>
-                  Yes
-                </td>
-                <td>
-                  Yes
-                </td>
-                <td>
-                  Any
-                </td>
-              </tr>
-              <tr>
-                <td>
                   <code>"insertLink"</code>
                 </td>
                 <td>
@@ -728,42 +711,6 @@
                 </td>
                 <td>
                   Yes
-                </td>
-                <td>
-                  Any
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <code>"deleteByComposition"</code>
-                </td>
-                <td>
-                  remove a part of the DOM in order to recompose this part
-                  using IME
-                </td>
-                <td>
-                  Yes
-                </td>
-                <td>
-                  Yes
-                </td>
-                <td>
-                  Any
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <code>"deleteCompositionText"</code>
-                </td>
-                <td>
-                  delete the current composition string before commiting a
-                  finalized string to the DOM
-                </td>
-                <td>
-                  Yes
-                </td>
-                <td>
-                  No
                 </td>
                 <td>
                   Any
@@ -1408,9 +1355,8 @@
             <tbody>
               <tr>
                 <td>
-                  <code>"insertText"</code>,
-                  <code>"insertCompositionText"</code> or
-                  <code>"insertFromComposition"</code>
+                  <code>"insertText"</code> or
+                  <code>"insertCompositionText"</code>
                 </td>
                 <td>
                   Any
@@ -1867,177 +1813,28 @@
     </section>
     <section>
       <h2>
-        Event order during IME composition
+        Input Event Order During Composition
       </h2>
       <p>
-        An IME composition causes several beforeinput events, not all of which
-        can be canceled.
+        The start of a composition is marked by dispatching a {{compositionstart}} event.
       </p>
-      <ol>
-        <li>
-          <p>
-            If the composition is starting with an empty initial composition
-            string (i.e. the composition is not recomposing an existing range
-            of the DOM), this step is skipped.
-          </p>
-          <ol>
-            <li>The UA extracts the initial composition string from the DOM.
-            </li>
-            <li>A beforeinput event with the inputType
-            <code>"deleteByComposition"</code> is <a href=
-            "https://www.w3.org/TR/uievents/#dispatch">dispatched</a>
-            [[UI-EVENTS]].
-            </li>
-            <li>Unless the beforeinput event has been canceled, the initial
-            composition string is removed from the DOM.
-            </li>
-            <li>Unless the beforeinput event has been canceled, an input event
-            with the inputType <code>"deleteByComposition"</code> is <a href=
-            "https://www.w3.org/TR/uievents/#dispatch">dispatched</a>
-            [[UI-EVENTS]].
-            </li>
-          </ol>
-          <div class="note">
-            <p>
-              <i>This note is not normative.</i>
-            </p>
-            <p>
-              The default action for this beforeinput event is the removal of
-              the targetRanges from the DOM (i.e. the initial composition
-              string will be removed from the DOM).
-            </p>
-            <p>
-              The beforeinput event can be canceled. Canceling the event will
-              prevent the browser from removing the initial composition string
-              from the DOM. Canceling or handling the event will not prevent
-              the composition from taking place or influence the contents of
-              the initial composition string.
-            </p>
-          </div>
-        </li>
-        <li>
-          <p>
-            A <code><a href=
-            "https://w3c.github.io/uievents/#event-type-compositionstart">compositionstart</a></code>
-            event is dispatched. [[UI-EVENTS]].
-          </p>
-        </li>
-        <li>
-          <p>
-            If the composition has an empty initial composition string, this
-            step is skipped.
-          </p>
-          <ol>
-            <li>A beforeinput event with the inputType
-            <code>"insertCompositionText"</code> is <a href=
-            "https://www.w3.org/TR/uievents/#dispatch">dispatched</a>
-            [[UI-EVENTS]] with the data attribute set to the initial
-            composition string.
-            </li>
-            <li>The DOM is updated with the insertion of the initial
-            composition string at the start of the selection.
-            </li>
-            <li>An input event with the inputType
-            <code>"insertCompositionText"</code> is <a href=
-            "https://www.w3.org/TR/uievents/#dispatch">dispatched</a>
-            [[UI-EVENTS]]
-            </li>
-          </ol>
-          <div class="note">
-            <p>
-              <i>This note is not normative.</i>
-            </p>
-            <p>
-              Notice that the beforeinput event cannot be canceled.
-            </p>
-          </div>
-        </li>
-        <li>
-          <p>
-            With each DOM update of the composition string:
-          </p>
-          <ol>
-            <li>A beforeinput event with the inputType
-            <code>"insertCompositionText"</code> is <a href=
-            "https://www.w3.org/TR/uievents/#dispatch">dispatched</a>
-            [[UI-EVENTS]] with the data attribute set to the updated contents
-            of the composition text.
-            </li>
-            <li>A <code><a href=
-            "https://w3c.github.io/uievents/#event-type-compositionupdate">compositionupdate</a></code>
-            event is dispatched. [[UI-EVENTS]].
-            </li>
-            <li>The DOM is updated.
-            </li>
-            <li>An input event with the inputType
-            <code>"insertCompositionText"</code> is <a href=
-            "https://www.w3.org/TR/uievents/#dispatch">dispatched</a>
-            [[UI-EVENTS]].
-            </li>
-          </ol>
-          <div class="note">
-            <p>
-              This step is repeated as long as no text is to be committed to
-              the DOM (i.e. is made to be part of the DOM outside the range
-              controlled by the composition).
-            </p>
-          </div>
-        </li>
-        <li>
-          <p>
-            When a part or the entire composition string is to be committed to
-            the DOM:
-          </p>
-          <ol>
-            <li>A beforeinput event with the inputType
-            <code>"deleteCompositionText"</code> is <a href=
-            "https://www.w3.org/TR/uievents/#dispatch">dispatched</a>
-            [[UI-EVENTS]].
-            </li>
-            <li>The contents of the range controlled by the composition process
-            is removed from the DOM.
-            </li>
-            <li>A beforeinput event with the inputType
-            <code>"insertFromComposition"</code> is <a href=
-            "https://www.w3.org/TR/uievents/#dispatch">dispatched</a>
-            [[UI-EVENTS]] with the data attribute set to the part of the final
-            composition string that is to be committed to the DOM.
-            </li>
-            <li>Unless the beforeinput event with the inputType
-            <code>"insertFromComposition"</code> has been canceled, the DOM is
-            updated with the part of the composition string that is to be
-            committed to the DOM inserted at the start of the selection.
-            </li>
-            <li>A <code><a href=
-            "https://w3c.github.io/uievents/#event-type-compositionend">compositionend</a></code>
-            event is dispatched. [[UI-EVENTS]].
-            </li>
-            <li>Unless the beforeinput event with the inputType
-            <code>"insertFromComposition"</code> has been canceled, a input
-            event with the inputType <code>"insertFromComposition"</code> is
-            <a href="https://www.w3.org/TR/uievents/#dispatch">dispatched</a>
-            </li>
-          </ol>
-        </li>
-        <li>
-          <p>
-            If only a part of the composition string was committed to the DOM,
-            while another part is not yet to be committed, the process starts
-            over from step 3 with the non-committed part of the final
-            composition string as the new initial composition string.
-          </p>
-        </li>
-      </ol>
-      <div class="note">
-        <p>
-          <i>This note is not normative.</i>
-        </p>
-        <p>
-          Note that while every composition only has one
-          <code>compositionstart</code> event, it may have several
-          <code>compositionend</code> events.
-        </p>
-      </div>
+      <p>
+        During a [=composition session=], whenever a [=text composition system=] updates its [=active text passage=], a {{compositionupdate}} event is dispatched.
+      </p>
+      <p>
+        After each {{compositionupdate}} event, a pair of {{beforeinput}} and {{input}} events are dispatched. The {{beforeinput}} and {{input}} events:
+      </p>
+      <ul>
+        <li>Are not cancellable</li>
+        <li>Have an {{inputType}} set to {{insertCompositionText}}</li>
+        <li>Have a {{data}} attribute equal to that of the {{compositionupdate}} event</li>
+        <li>Have a [=target range=] that surrounds the [=active text passage=] of the composition</li>
+      </ul>
+      <p>The DOM contents of the [=active text passage=] are updated after the {{beforeinput}} event is dispatched and before the {{input}} event is dispatched.</p>
+      </p>
+      <p>
+        The end of a [=composition session=] is marked by dispatching a {{compositionend}} event.
+      </p>
     </section>
     <section>
       <h2>


### PR DESCRIPTION
This PR eliminates three inputTypes from beforeinput/input events: insertFromComposition, deleteByComposition, and deleteCompositionText.

It also clarifies the order of the insertCompositionText beforeinput and input events with respect to composition events.  The proposed behavior is that beforeinput and input events for insertCompositionText occur only after compositionupdate events.

Additionally, a note stating that multiple compositionend events may occur for one compositionstart event was removed.

The result is that the composition sequence is:

* A compositionstart event
* Multiple occurrences of this sequence:
    * A compositionupdate event
    * A beforeinput event with inputType = insertCompositionText
    * An input event with inputType = insertCompositionText
* A compositionend event


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/BoCupp-Microsoft/input-events/pull/122.html" title="Last updated on Sep 9, 2021, 6:59 AM UTC (288c62c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/input-events/122/00c2127...BoCupp-Microsoft:288c62c.html" title="Last updated on Sep 9, 2021, 6:59 AM UTC (288c62c)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/BoCupp-Microsoft/input-events/pull/122.html" title="Last updated on Mar 10, 2022, 2:49 PM UTC (288c62c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/input-events/122/00c2127...BoCupp-Microsoft:288c62c.html" title="Last updated on Mar 10, 2022, 2:49 PM UTC (288c62c)">Diff</a>