### PR TITLE
Add event order related to insertFromPaste, fixes #117

### DIFF
--- a/index.html
+++ b/index.html
@@ -1337,15 +1337,6 @@
             Other specifications may expand on this definition.
           </div>
           <div class="note">
-            <p>
-              <i>This note is not normative.</i>
-            </p>
-            When an <code>"insertFromPaste"</code> {{beforeinput}}
-            event is dispatched, it should be preceded by a
-            <a href="https://www.w3.org/TR/clipboard-apis/#clipboard-event-paste">paste</a>
-            [[CLIPBOARD-APIS]] event.
-          </div>
-          <div class="note">
             The existence of the above mentioned <code>inputTypes</code> does
             not mean that any given implementation will support all of these.
             But if a given browser supports an editing operation which
@@ -2047,6 +2038,15 @@
           <code>compositionend</code> events.
         </p>
       </div>
+    </section>
+    <section>
+      <h2>Event order when using <code>"insertFromPaste"</code></h2>
+      <p>
+        When an <code>"insertFromPaste"</code> {{beforeinput}}
+        event is dispatched, it MUST be preceded by a
+        <a href="https://www.w3.org/TR/clipboard-apis/#clipboard-event-paste">paste</a>
+        [[CLIPBOARD-APIS]] event.
+      </p>
     </section>
     <section>
       <h2>

--- a/index.html
+++ b/index.html
@@ -1337,6 +1337,15 @@
             Other specifications may expand on this definition.
           </div>
           <div class="note">
+            <p>
+              <i>This note is not normative.</i>
+            </p>
+            When an <code>"insertFromPaste"</code> <code>beforeinput</code>
+            event is dispatched, it should be preceded by a
+            <a href="https://www.w3.org/TR/clipboard-apis/#clipboard-event-paste">paste</a>
+            [[CLIPBOARD-APIS]] event.
+          </div>
+          <div class="note">
             The existence of the above mentioned <code>inputTypes</code> does
             not mean that any given implementation will support all of these.
             But if a given browser supports an editing operation which

--- a/index.html
+++ b/index.html
@@ -1340,7 +1340,7 @@
             <p>
               <i>This note is not normative.</i>
             </p>
-            When an <code>"insertFromPaste"</code> <code>beforeinput</code>
+            When an <code>"insertFromPaste"</code> {{beforeinput}}
             event is dispatched, it should be preceded by a
             <a href="https://www.w3.org/TR/clipboard-apis/#clipboard-event-paste">paste</a>
             [[CLIPBOARD-APIS]] event.


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/input-events/pull/123.html" title="Last updated on Oct 8, 2021, 3:26 PM UTC (8753582)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/input-events/123/00c2127...8753582.html" title="Last updated on Oct 8, 2021, 3:26 PM UTC (8753582)">Diff</a>