### PR TITLE
Deploy w3c/spec-prod

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -1,0 +1,12 @@
+name: CI
+on:
+  pull_request: {}
+  push:
+    branches: ["gh-pages"]
+jobs:
+  main:
+    name: Build and Validate
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: w3c/spec-prod@v2


### PR DESCRIPTION
Closes #125

Similar to #118 but without actual publish. For now this will only work as a validator.