### PR TITLE
Changes for EditContext

### DIFF
--- a/index.html
+++ b/index.html
@@ -1642,8 +1642,7 @@
                     Trusted Targets
                   </th>
                   <td>
-                    Any <code>Element</code> with <code>contenteditable</code>
-                    attribute enabled.
+                    Any <code>Element</code> that is an [=editing host=].
                   </td>
                 </tr>
                 <tr>

--- a/index.html
+++ b/index.html
@@ -1653,11 +1653,27 @@
                     action</a> [[UI-EVENTS]]
                   </th>
                   <td>
-                    Varies: 'Update the DOM' for contentEditable=typing editing
-                    hosts for inputTypes <code>"insertCompositionText"</code>
-                    and <code>"deleteCompositionText"</code>. 'Update the DOM
-                    element' for <code>contentEditable="true"</code> editing
-                    hosts for all inputTypes. None otherwise.
+                    <ul>
+                      <li>
+                        For contentEditable=typing editing
+                        hosts for inputTypes <code>"insertCompositionText"</code>
+                        and <code>"deleteCompositionText"</code>: 'Update the DOM'.
+                      </li>
+                      <li>
+                        For <code>contentEditable="true"</code> editing hosts
+                        for all inputTypes: 'Update the DOM'.
+                      </li>
+                      <li>
+                        For
+                        <a href="https://w3c.github.io/edit-context/#dfn-editcontext-editing-host">EditContext editing hosts</a>
+                        for all inputTypes:
+                        <a href="https://w3c.github.io/edit-context/#dfn-handle-input-for-editcontext">Handle input for EditContext</a>
+                        given the editing host element.
+                      </li>
+                      <li>
+                        None otherwise.
+                      </li>
+                    </ul>
                   </td>
                 </tr>
                 <tr>
@@ -1788,9 +1804,14 @@
                 </tr>
               </table>
               <p>
-                A [=user agent=] MUST [=dispatch=] this event immediately after
-                the DOM has been updated due to a user expressed intention to
-                change the document contents which the browser has handled.
+                A [=user agent=] MUST [=dispatch=] this event immediately after the DOM has been
+                updated due to  user expressed intention to change the document contents which the
+                browser has handled. If the browser makes no DOM change, either because the
+                editing host is an
+                <a href="https://w3c.github.io/edit-context/#dfn-editcontext-editing-host">EditContext editing host</a>
+                (which does not do automatic DOM changes) or because the [=user agent=]
+                concludes that no DOM change is needed, the user agent MUST NOT
+                dispatch this event.
               </p>
             </dd>
           </dl>

--- a/index.html
+++ b/index.html
@@ -1659,7 +1659,7 @@
                         and <code>"deleteCompositionText"</code>: 'Update the DOM'.
                       </li>
                       <li>
-                        For <code>contentEditable="true"</code> editing hosts
+                        For <code>contentEditable="true"</code> [=editing hosts=]
                         for all inputTypes: 'Update the DOM'.
                       </li>
                       <li>
@@ -1667,7 +1667,7 @@
                         <a href="https://w3c.github.io/edit-context/#dfn-editcontext-editing-host">EditContext editing hosts</a>
                         for all inputTypes:
                         <a href="https://w3c.github.io/edit-context/#dfn-handle-input-for-editcontext">Handle input for EditContext</a>
-                        given the editing host element.
+                        given the [=editing host=] element.
                       </li>
                       <li>
                         None otherwise.


### PR DESCRIPTION
Not to be landed until we have high confidence that EditContext will be implemented, e.g. when shipped in at least one browser.

- Add `Handle input for EditContext` as default action for `beforeinput`.
- Clarify that `input` is not fired for EditContext editing hosts.

Resolves https://github.com/w3c/input-events/issues/143.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dandclark/input-events/pull/145.html" title="Last updated on Oct 6, 2023, 6:31 PM UTC (4b95f1a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/input-events/145/383151e...dandclark:4b95f1a.html" title="Last updated on Oct 6, 2023, 6:31 PM UTC (4b95f1a)">Diff</a>