### PR TITLE
make code point replacement normative, based on resolution on #146

### DIFF
--- a/index.html
+++ b/index.html
@@ -1282,30 +1282,6 @@
             more complex elements or merge paragraphs if the caret is at the
             end of a text node.
           </div>
-          <div class="note" data-link-for="InputEvent">
-            <p>
-              <i>This note is not normative.</i>
-            </p>In some scripts on some platforms, backward deletion within a
-            text node with a collapsed selection will delete a single <a href=
-            "https://infra.spec.whatwg.org/#code-points">code point</a>
-            [[INFRA]] rather than an entire [=grapheme cluster=]. The <a>getTargetRanges()</a> method can be
-            used to find out how many <a href=
-            "https://infra.spec.whatwg.org/#code-points">code points</a>
-            [[INFRA]] the browser will remove by default if deleting within a
-            text node.
-          </div>
-          <div class="note" data-link-for="InputEvent">
-            <p>
-              <i>This note is not normative.</i>
-            </p>In some scripts on some platforms, forward deletion within a
-            text node with a collapsed selection will delete an entire [=grapheme cluster=] rather than a single <a href=
-            "https://infra.spec.whatwg.org/#code-points">code point</a>
-            [[INFRA]]. The <a>getTargetRanges()</a> method can be used to find
-            out how many <a href=
-            "https://infra.spec.whatwg.org/#code-points">code points</a>
-            [[INFRA]] the browser will remove by default if deleting within a
-            text node.
-          </div>
           <p>
             <dfn><code>data</code></dfn> holds information plaintext data
             related to what is to be added to the document.
@@ -1522,9 +1498,19 @@
           </table>
           <p>
             <dfn data-dfn-for="InputEvent" data-lt="targetRange">getTargetRanges()</dfn> returns an
-            arrays <a>StaticRanges</a> that will be affected by the event if it
-            is not cancelled.
+            arrays <a>StaticRanges</a> representing the text that the event will modify if it is not canceled.
+            The returned <a>StaticRanges</a> MUST cover only the <a href=“https://infra.spec.whatwg.org/#code-points”>code points</a>
+            [[INFRA]] that the browser would normally replace, even if they are only part of a [=grapheme cluster=].
           </p>
+          <div class="note" data-link-for="InputEvent">
+            <p>
+              <i>This note is not normative.</i>
+            </p>
+            Depending on the script and the platform, deleting backward or forward in a text node with a collapsed selection may affect
+            a single <a href= “https://infra.spec.whatwg.org/#code-points”>code point</a> [[INFRA]] or a whole [=grapheme cluster=].
+            For example, deleting backward in a text node containing “café” may remove either the acute accent or the entire “é” character,
+            depending on the script and the platform. 
+          </div>
         </section><!-- interface-InputEvent-Attributes -->
         <section id="interface-InputEvent-Methods" data-dfn-for="InputEvent">
           <h5>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 520  :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Dec 14, 2023, 2:43 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Finput-events%2F05269ac28e6a3c559f274d0575f984ba7c055549%2Findex.html%3FisPreview%3Dtrue)

```
error code: 520
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/input-events%23148.)._
</details>
