### PR TITLE
Link to EditContext-handled inputTypes

### DIFF
--- a/index.html
+++ b/index.html
@@ -1646,7 +1646,8 @@
                       </li>
                       <li>For <a href=
                       "https://w3c.github.io/edit-context/#dfn-editcontext-editing-host">
-                        EditContext editing hosts</a> for all inputTypes:
+                        EditContext editing hosts</a> for <a href=
+                        "https://w3c.github.io/edit-context/#dfn-editcontext-handled-inputtype">EditContext-handled inputTypes</a>:
                         <a href=
                         "https://w3c.github.io/edit-context/#dfn-handle-input-for-editcontext">
                         Handle input for EditContext</a> given the [=editing


### PR DESCRIPTION
For `beforeinput`, only pass the event to EditContext for `inputTypes` that EditContext expects to handle.
See https://github.com/w3c/edit-context/pull/101.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dandclark/input-events/pull/154.html" title="Last updated on Jun 21, 2024, 10:21 PM UTC (46720d8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/input-events/154/9e4ebc1...dandclark:46720d8.html" title="Last updated on Jun 21, 2024, 10:21 PM UTC (46720d8)">Diff</a>