### PR TITLE
Add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+<!-- Please fill in the sections below when making normative changes. Feel free to remove the sections when only making non-normative changes. -->
+
+For normative changes, the following tasks have been completed:
+ * [ ] Editing WG resolution on the proposed changes, with at least two implementers participating and not objecting:
+   * [ ] WebKit
+   * [ ] Chromium
+   * [ ] Gecko
+
+ * [ ] For browsers that are shipping the feature, implementation bugs are filed for the proposed changes (link to bug, or write "Not Implementing"):
+   * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
+   * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
+   * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)
+ 


### PR DESCRIPTION
Per resolution to https://github.com/w3c/editing/issues/463, https://github.com/w3c/edit-context/pull/100 introduced a PR template that was agreed upon by the Editing WG. This change introduces the same template in this repository.