### PR TITLE
"text" => "content"

### DIFF
--- a/index.html
+++ b/index.html
@@ -465,7 +465,7 @@
                   <code>"insertReplacementText"</code>
                 </td>
                 <td>
-                  insert or replace existing text by means of a spell checker,
+                  insert or replace existing content by means of a spell checker,
                   auto-correct, writing suggestions or similar
                 </td>
                 <td>
@@ -1493,7 +1493,7 @@
           <p>
             <dfn data-dfn-for="InputEvent" data-lt=
             "targetRange">getTargetRanges()</dfn> returns an array of
-            <a>StaticRanges</a> representing the text that the event will
+            <a>StaticRanges</a> representing the content that the event will
             modify if it is not canceled. The returned <a>StaticRanges</a> MUST
             cover only the <a data-cite="infra#code-points">code points</a>
             that the browser would normally replace, even if they are only part


### PR DESCRIPTION
In two places the term "text" should be replaced with "content" as replacements could also include other content than just text.

This change is not a normative change and it will not change how browsers work. It is merely a better choice of words. It briefly came up during a Editing WG meeting.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/input-events/pull/164.html" title="Last updated on Oct 18, 2024, 8:29 AM UTC (5aac922)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/input-events/164/95b6583...5aac922.html" title="Last updated on Oct 18, 2024, 8:29 AM UTC (5aac922)">Diff</a>