### PR TITLE
Remove stray reference to 'deleteCompositionText' input type

### DIFF
--- a/index.html
+++ b/index.html
@@ -1638,8 +1638,8 @@
                   <td>
                     <ul>
                       <li>For contentEditable=typing editing hosts for
-                      inputTypes <code>"insertCompositionText"</code> and
-                      <code>"deleteCompositionText"</code>: 'Update the DOM'.
+                      inputType <code>"insertCompositionText"</code>: 'Update
+                      the DOM'.
                       </li>
                       <li>For <code>contentEditable="true"</code> [=editing
                       hosts=] for all inputTypes: 'Update the DOM'.


### PR DESCRIPTION
See https://github.com/w3c/input-events/pull/122, which removes this type.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/marijnh/input-events/pull/173.html" title="Last updated on Jul 16, 2025, 12:29 PM UTC (87fdbf6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/input-events/173/ec8c6f5...marijnh:87fdbf6.html" title="Last updated on Jul 16, 2025, 12:29 PM UTC (87fdbf6)">Diff</a>