### PR TITLE
Update getTargetRanges definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -1494,8 +1494,12 @@
             <dfn data-dfn-for="InputEvent" data-lt=
             "targetRange">getTargetRanges()</dfn> returns an array of
             <a>StaticRanges</a> representing the content that the event will
-            modify if it is not canceled. The returned <a>StaticRanges</a> MUST
-            cover only the <a data-cite="infra#code-points">code points</a>
+            modify if it is not canceled, if the [=editing host=] is
+            contenteditable node or an <a href=
+            "https://w3c.github.io/edit-context/#dfn-editcontext-editing-host">
+            EditContext editing host</a>. Otherwise this method will return
+            none. The returned <a>StaticRanges</a> MUST cover only the <a
+            data-cite="infra#code-points">code points</a>
             that the browser would normally replace, even if they are only part
             of a [=grapheme cluster=].
           </p>


### PR DESCRIPTION
Update the `getTargetRanges` definition to include EditContext as mentioned in https://github.com/w3c/edit-context/issues/86.
<!-- Please fill in the sections below when making normative changes. Feel free to remove the sections when only making non-normative changes. -->

For normative changes, the following tasks have been completed:
 * [x] Editing WG resolution on the proposed changes, with at least two implementers participating and not objecting:
   * [x] WebKit
   * [x] Chromium
   * [x] Gecko

 * [x] For browsers that are shipping the feature, implementation bugs are filed for the proposed changes (link to bug, or write "Not Implementing"):
   * [x] WebKit (https://github.com/WebKit/standards-positions/issues/243)
   * [x] Chromium (https://issues.chromium.org/issues/40642681)
   * [x] Gecko (https://github.com/mozilla/standards-positions/issues/199)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ashishkum-ms/input-events/pull/174.html" title="Last updated on Aug 14, 2025, 8:44 AM UTC (823072a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/input-events/174/c533952...ashishkum-ms:823072a.html" title="Last updated on Aug 14, 2025, 8:44 AM UTC (823072a)">Diff</a>